### PR TITLE
Install the Policy Kit configuration for NetworkManager

### DIFF
--- a/roles/ideascube/files/ideascube-networkmanager.pkla
+++ b/roles/ideascube/files/ideascube-networkmanager.pkla
@@ -1,0 +1,6 @@
+[Allow ideascube to enable Wi-Fi]
+Identity=unix-user:ideascube
+Action=org.freedesktop.NetworkManager.enable-disable-wifi
+ResultActive=yes
+ResultInactive=yes
+ResultAny=yes

--- a/roles/ideascube/tasks/main.yml
+++ b/roles/ideascube/tasks/main.yml
@@ -80,6 +80,9 @@
   service: name=uwsgi enabled=yes
   when: ideascube_version.stdout == ""
 
+- name: Set up Policy Kit authorizations
+  copy: src=ideascube-networkmanager.pkla dest=/var/lib/polkit-1/localauthority/20-org.d/ideascube-networkmanager.pkla owner=root group=root mode=644
+
 # Should be already packaged !!!
 - name: Install libjpeg-dev
   apt: name=libjpeg-dev state=latest


### PR DESCRIPTION
The ideascube user (under which the ideascube app is running) needs the permissions to enable/disable the Wi-Fi via NetworkManager.
