### PR TITLE
services: Add the require Policy Kit stuff

### DIFF
--- a/roles/ideascube/files/ideascube-systemd.pkla
+++ b/roles/ideascube/files/ideascube-systemd.pkla
@@ -1,0 +1,6 @@
+[Allow ideascube to manage units]
+Identity=unix-user:ideascube
+Action=org.bsf.ideascube.pkexec.systemctl
+ResultActive=yes
+ResultInactive=yes
+ResultAny=yes

--- a/roles/ideascube/files/org.bsf.ideascube.policy
+++ b/roles/ideascube/files/org.bsf.ideascube.policy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+
+  <vendor>The Ideascube Project</vendor>
+  <vendor_url>https://github.com/ideascube</vendor_url>
+
+  <action id="org.bsf.ideascube.pkexec.systemctl">
+    <description>Manage systemd units with systemctl</description>
+    <message>Authentication is required for service management.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>no</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/bin/systemctl</annotate>
+  </action>
+
+</policyconfig>

--- a/roles/ideascube/tasks/main.yml
+++ b/roles/ideascube/tasks/main.yml
@@ -72,8 +72,15 @@
   file: src=/etc/uwsgi/apps-available/ideascube.ini dest=/etc/uwsgi/apps-enabled/ideascube.ini state=link
   when: ideascube_version.stdout == ""
 
-- name: Set up Policy Kit authorizations for wifi managment
-  copy: src=ideascube-networkmanager.pkla dest=/var/lib/polkit-1/localauthority/20-org.d/ideascube-networkmanager.pkla owner=root group=root mode=644
+- name: Set up the custom Policy Kit actions
+  copy: src=org.bsf.ideascube.policy dest=/usr/share/polkit-1/actions/org.bsf.ideascube.policy owner=root group=root mode=644
+  when: ideascube_version.stdout == ""
+
+- name: Set up the Policy Kit authorizations
+  copy: src={{ item }} dest=/var/lib/polkit-1/localauthority/20-org.d/{{ item }} owner=root group=root mode=644
+  with_items:
+  - ideascube-networkmanager.pkla
+  - ideascube-systemd.pkla
   when: ideascube_version.stdout == ""
   ignore_errors: yes
 


### PR DESCRIPTION
We target Debian Jessie, which has systemd 215.

Unfortunately, the nice Policy Kit integration into the systemd DBus API was added after systemd 216.

As a result, the ideascube app can't call systemd through its DBus API, it has to use the `systemctl` command.

This commit defines a new Policy Kit action, corresponding to the `pkexec systemctl ...` command, and lets the `ideascube` user run it without needing to authenticate.
