### PR TITLE
Stop modifying the ideascube config for nginx.

### DIFF
--- a/roles/upgradeIdc/tasks/main.yml
+++ b/roles/upgradeIdc/tasks/main.yml
@@ -55,12 +55,6 @@
   file: path=/etc/apt/apt.conf.d/9999IDEASCUBEISABADBADBOY state=absent
   when: st.stat.exists == False
 
-- name: Remove linsting on 443 because the port is alredy used by sslh
-  lineinfile: dest=/etc/nginx/sites-available/ideascube regexp='443' state=absent
-  notify: restart nginx
-  when: st.stat.exists == False
-  ignore_errors: yes
-
 - name: Copy startup script
   copy: src=hostapd dest=/etc/systemd/system/hostapd.service owner=root group=root mode=664
   when: st.stat.exists == False


### PR DESCRIPTION
This change should have been made into ideascube's package
(extras/nginx/ideascube) and is now commited there.

Fixes #30.

dpkg now thinks the vhost has been manually modified, and won't install
its new version, leaving a .dpkg-dist file behind. We'll have to add a
file removal into ideascube's postinst script for some time :p
