### PR TITLE
Backup the ideascube database before upgrading

### DIFF
--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -11,7 +11,7 @@
   tags: ['master', 'update']
 
 - name: Get ideascube installed (versions.stdout_lines.0) et candidate (versions.stdout_lines.1) version 
-- raw: LANG=C apt-cache policy ideascube | awk ' $1~/Installed|Candidate/ { print $2 }' 
+  raw: LANG=C apt-cache policy ideascube | awk ' $1~/Installed|Candidate/ { print $2 }' 
   register: versions
 
 - set_fact: ideascube_installed="{{ versions.stdout_lines.0 }}"

--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -50,9 +50,9 @@
 
   - name: upgrade ideascube 0.17.0 if ideascube >= 0.14.0
     apt: name=ideascube=0.17.0 update_cache=yes force=yes dpkg_options="force-confnew"
+    register: is_upgraded
 
   when: ideascube_installed | version_compare('0.14.0', '>=')
-  register: is_upgraded
   tags:
     - update
 
@@ -62,9 +62,9 @@
 
   - name: upgrade ideascube to 0.12.2 if ideascube < 0.13.0
     apt: name=ideascube=0.12.2 update_cache=yes force=yes dpkg_options="force-confnew"
+    register: is_upgraded
 
   when: ideascube_installed | version_compare('0.13.0', '<')
-  register: is_upgraded
   tags:
     - update
 
@@ -74,9 +74,9 @@
 
   - name: freeze ideascube to 0.13.0 if ideascube = 0.13.0
     apt: name=ideascube=0.13.0 update_cache=yes force=yes dpkg_options="force-confnew"
-
+    register: is_upgraded
+    
   when: ideascube_installed | version_compare('0.13.0', '==')
-  register: is_upgraded
   tags:
     - update
 

--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -10,13 +10,15 @@
   apt: name=python3-minimal state=present
   tags: ['master', 'update']
 
-- name: Get ideascube version
-  shell: dpkg-query -W  ideascube  | awk '{print $2}' ; echo
-  register: ideascube_oldversion
+- name: Get ideascube installed (versions.stdout_lines.0) et candidate (versions.stdout_lines.1) version 
+- raw: LANG=C apt-cache policy ideascube | awk ' $1~/Installed|Candidate/ { print $2 }' 
+  register: versions
+
+- set_fact: ideascube_installed="{{ versions.stdout_lines.0 }}"
   tags: 
     - update
 
-- set_fact: ideascube_oldversion="{{ ideascube_oldversion.stdout }}"
+- set_fact: ideascube_candidate="{{ versions.stdout_lines.1 }}"
   tags: 
     - update
 
@@ -42,29 +44,41 @@
   when: (ansible_architecture == "armhf" or ansible_architecture == "armv7l")
     and sda1.stat.isblk == True
 
-- name: Get ideascube version
-  shell: dpkg-query -W  ideascube  | awk '{print $2}' ; echo
-  register: ideascube_version
-  tags:
-    - update
+- block:
 
-- name: upgrade ideascube 0.17.0 if ideascube >= 0.14.0
-  apt: name=ideascube=0.17.0 update_cache=yes force=yes dpkg_options="force-confnew"
-  when: ideascube_version.stdout | version_compare('0.14.0', '>=')
+  - name: Backup data before upgrading
+    shell: cp /var/ideascube/main/default.sqlite /var/ideascube/main/default.sqlite-{{ ideascube_installed }}-{{ ansible_date_time["date"] }}-{{ ansible_date_time["time"] }}
+
+  - name: upgrade ideascube 0.17.0 if ideascube >= 0.14.0
+    apt: name=ideascube=0.17.0 update_cache=yes force=yes dpkg_options="force-confnew"
+
+  when: ideascube_installed | version_compare('0.14.0', '>=')
   register: is_upgraded
   tags:
     - update
 
-- name: upgrade ideascube to 0.12.2 if ideascube < 0.13.0
-  apt: name=ideascube=0.12.2 update_cache=yes force=yes dpkg_options="force-confnew"
-  when: ideascube_version.stdout | version_compare('0.13.0', '<')
+- block:
+
+  - name: Backup data before upgrading
+    shell: cp /var/ideascube/main/default.sqlite /var/ideascube/main/default.sqlite-{{ ideascube_installed }}-{{ ansible_date_time["date"] }}-{{ ansible_date_time["time"] }}
+
+  - name: upgrade ideascube to 0.12.2 if ideascube < 0.13.0
+    apt: name=ideascube=0.12.2 update_cache=yes force=yes dpkg_options="force-confnew"
+
+  when: ideascube_installed | version_compare('0.13.0', '<')
   register: is_upgraded
   tags:
     - update
 
-- name: freeze ideascube to 0.13.0 if ideascube = 0.13.0
-  apt: name=ideascube=0.13.0 update_cache=yes force=yes dpkg_options="force-confnew"
-  when: ideascube_version.stdout | version_compare('0.13.0', '==')
+- block:
+
+  - name: Backup data before upgrading
+    shell: cp /var/ideascube/main/default.sqlite /var/ideascube/main/default.sqlite-{{ ideascube_installed }}-{{ ansible_date_time["date"] }}-{{ ansible_date_time["time"] }}
+
+  - name: freeze ideascube to 0.13.0 if ideascube = 0.13.0
+    apt: name=ideascube=0.13.0 update_cache=yes force=yes dpkg_options="force-confnew"
+
+  when: ideascube_installed | version_compare('0.13.0', '==')
   register: is_upgraded
   tags:
     - update
@@ -79,7 +93,7 @@
   become: yes
   become_user: ideascube
   command: ideascube reset_home
-  when: ideascube_oldversion | version_compare('0.13.0', '<')
+  when: ideascube_installed | version_compare('0.13.0', '<')
     and is_upgraded.changed == True
   tags:
     - update
@@ -155,18 +169,15 @@
   register: ideascube_newversion
   tags: ['master', 'custom', 'update']
 
-- set_fact: ideascube_version="{{ ideascube_newversion.stdout }}"
+- debug: msg="ideascube {{ ideascube_newversion.stdout }} is now the current version."
   tags: ['master', 'custom', 'update']
 
-- debug: msg="ideascube {{ ideascube_version }} is now the current version."
-  tags: ['master', 'custom', 'update']
-
-- name: Enable cards on homepage for ideascube upgrading to > 0.13
+- name: Update catalog 
   become: yes
   become_user: ideascube
   command: ideascube catalog cache update
-  when: ideascube_oldversion | version_compare('0.13.0', '>') 
-    and ideascube_version | version_compare('0.15.0', '>=')
+  when: ideascube_installed | version_compare('0.13.0', '>') 
+    and ideascube_newversion.stdout | version_compare('0.15.0', '>=')
     and is_upgraded.changed == True
   tags:
     - update

--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -13,6 +13,8 @@
 - name: Get ideascube installed (versions.stdout_lines.0) et candidate (versions.stdout_lines.1) version 
   raw: LANG=C apt-cache policy ideascube | awk ' $1~/Installed|Candidate/ { print $2 }' 
   register: versions
+  tags: 
+    - update
 
 - set_fact: ideascube_installed="{{ versions.stdout_lines.0 }}"
   tags: 
@@ -75,7 +77,7 @@
   - name: freeze ideascube to 0.13.0 if ideascube = 0.13.0
     apt: name=ideascube=0.13.0 update_cache=yes force=yes dpkg_options="force-confnew"
     register: is_upgraded
-    
+
   when: ideascube_installed | version_compare('0.13.0', '==')
   tags:
     - update

--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -45,7 +45,6 @@
     and sda1.stat.isblk == True
 
 - block:
-
   - name: Backup data before upgrading
     shell: cp /var/ideascube/main/default.sqlite /var/ideascube/main/default.sqlite-{{ ideascube_installed }}-{{ ansible_date_time["date"] }}-{{ ansible_date_time["time"] }}
 
@@ -58,7 +57,6 @@
     - update
 
 - block:
-
   - name: Backup data before upgrading
     shell: cp /var/ideascube/main/default.sqlite /var/ideascube/main/default.sqlite-{{ ideascube_installed }}-{{ ansible_date_time["date"] }}-{{ ansible_date_time["time"] }}
 
@@ -71,7 +69,6 @@
     - update
 
 - block:
-
   - name: Backup data before upgrading
     shell: cp /var/ideascube/main/default.sqlite /var/ideascube/main/default.sqlite-{{ ideascube_installed }}-{{ ansible_date_time["date"] }}-{{ ansible_date_time["time"] }}
 

--- a/roles/ideascube/tasks/main.yml
+++ b/roles/ideascube/tasks/main.yml
@@ -4,5 +4,5 @@
 
 - include: ideascube.yml
 
-- include: ../../../post_install.yml task=ideascube task_version="{{ ideascube_version }}"
+- include: ../../../post_install.yml task=ideascube task_version="{{ ideascube_newversion.stdout }}"
   tags: ['custom', 'update']


### PR DESCRIPTION
This playbook needs to be improve and tested. This introduce the use of
block feature which allow us to group tasks and though perform a backup
before upgrading ideascube.