### PR TITLE
Periodically clean ideascube leftover files

### DIFF
--- a/roles/ideascube/files/ideascube_leftover_files.service
+++ b/roles/ideascube/files/ideascube_leftover_files.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run ideascube clean leftover-files
+RefuseManualStart=no
+RefuseManualStop=yes
+ 
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ideascube clean leftover-files

--- a/roles/ideascube/files/ideascube_leftover_files.service
+++ b/roles/ideascube/files/ideascube_leftover_files.service
@@ -5,4 +5,5 @@ RefuseManualStop=yes
  
 [Service]
 Type=oneshot
+TimeoutStartSec=8min
 ExecStart=/usr/bin/ideascube clean leftover-files

--- a/roles/ideascube/files/ideascube_leftover_files.timer
+++ b/roles/ideascube/files/ideascube_leftover_files.timer
@@ -1,7 +1,5 @@
 [Unit]
 Description=Run ideascube clean leftover-files weekly and on boot
-RefuseManualStart=no
-RefuseManualStop=no
 
 [Timer]
 OnBootSec=10min

--- a/roles/ideascube/files/ideascube_leftover_files.timer
+++ b/roles/ideascube/files/ideascube_leftover_files.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run ideascube clean leftover-files weekly and on boot
+RefuseManualStart=no
+RefuseManualStop=no
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=1w
+
+[Install]
+WantedBy=timers.target

--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -191,3 +191,15 @@
     and is_upgraded.changed == True
   tags:
     - update
+
+- name: Copy ideascube_leftover_files.service systemd unit
+  copy: src=ideascube_leftover_files.service dest=/etc/systemd/system/ideascube_leftover_files.service
+  tags: ['master', 'custom', 'update']
+
+- name: Copy ideascube_leftover_files.timer systemd unit
+  copy: src=ideascube_leftover_files.timer dest=/etc/systemd/system/ideascube_leftover_files.timer
+  tags: ['master', 'custom', 'update']
+
+- name: Enable unit ideascube_leftover_files.timer
+  service: name=ideascube_leftover_files.timer enabled=yes
+  tags: ['master', 'custom', 'update']


### PR DESCRIPTION
This PR aim to add the feature of periodically clean leftover files as requested in #68 

It use systemd timer instead of cron job. This give us more flexibility as the job is executed at each startup after 10min and each week if the device is not rebooting often. 