### PR TITLE
Restart dnsmasq

### DIFF
--- a/roles/dnsmasq/handler/main.yml
+++ b/roles/dnsmasq/handler/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart dsnmasq
+  service: name=dsnmasq state=restarted
+  tags: ['master', 'custom','rename']
+  

--- a/roles/dnsmasq/handler/main.yml
+++ b/roles/dnsmasq/handler/main.yml
@@ -1,5 +1,0 @@
----
-- name: restart dsnmasq
-  service: name=dsnmasq state=restarted
-  tags: ['master', 'custom','rename']
-  

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -13,4 +13,5 @@
 
 - name: Create a new interfaces file
   template: src=interfaces.j2 dest=/etc/network/interfaces backup=yes
+  notify: restart dnsmasq
   tags: ['master', 'custom','rename']

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -13,5 +13,8 @@
 
 - name: Create a new interfaces file
   template: src=interfaces.j2 dest=/etc/network/interfaces backup=yes
-  notify: restart dnsmasq
+  tags: ['master', 'custom','rename']
+
+- name: restart dsnmasq
+  service: name=dsnmasq state=restarted
   tags: ['master', 'custom','rename']

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -16,5 +16,5 @@
   tags: ['master', 'custom','rename']
 
 - name: restart dsnmasq
-  service: name=dsnmasq state=restarted
+  service: name=dnsmasq state=restarted
   tags: ['master', 'custom','rename']


### PR DESCRIPTION
During installation, sometime the device loose domaine name resolution.
To prevent this, we restart dnsmasq