### PR TITLE
Switch to dynamic branch

### DIFF
--- a/buildMyCube.sh
+++ b/buildMyCube.sh
@@ -353,6 +353,7 @@ do
 
         -b|--branch)
             BRANCH=$2
+            GIT_BRANCH="git_branch=$2"
         shift
         ;;
 
@@ -377,11 +378,11 @@ if [[ "$START" = "1" ]]; then
     [ -x /usr/local/bin/ansible ] || install_ansible
     [ -d ${ANSIBLECUBE_PATH} ] || clone_ansiblecube
 
-    $ANSIBLE_BIN -C $BRANCH -d $ANSIBLECUBE_PATH -i hosts -U $GIT_REPO_URL main.yml --extra-vars "$MANAGMENT $NAME $TIMEZONE $HOST_NAME $CONFIGURE $WIFIPWD" $TAGS > /var/log/ansible-pull.log 2>&1 &
+    $ANSIBLE_BIN -C $BRANCH -d $ANSIBLECUBE_PATH -i hosts -U $GIT_REPO_URL main.yml --extra-vars "$MANAGMENT $NAME $TIMEZONE $HOST_NAME $CONFIGURE $WIFIPWD $GIT_BRANCH" $TAGS > /var/log/ansible-pull.log 2>&1 &
     sleep 2
 
-    echo "$ANSIBLE_BIN -C $BRANCH -d $ANSIBLECUBE_PATH -i hosts -U $GIT_REPO_URL main.yml --extra-vars \"$MANAGMENT $NAME $TIMEZONE $HOST_NAME $CONFIGURE $WIFIPWD\" $TAGS" >> /var/lib/ansible/ansible-pull-cmd-line.sh
-    dialog --keep-window --begin 2 20  --infobox "[+] Command line stored in /var/lib/ansible/ansible-pull-cmd-line.sh\n\n$ANSIBLE_BIN -C $BRANCH -d $ANSIBLECUBE_PATH -i hosts -U $GIT_REPO_URL main.yml --extra-vars \"$MANAGMENT $NAME $TIMEZONE $HOST_NAME $CONFIGURE $WIFIPWD\" $TAGS" 8 150 \
+    echo "$ANSIBLE_BIN -C $BRANCH -d $ANSIBLECUBE_PATH -i hosts -U $GIT_REPO_URL main.yml --extra-vars \"$MANAGMENT $NAME $TIMEZONE $HOST_NAME $CONFIGURE $WIFIPWD $GIT_BRANCH\" $TAGS" >> /var/lib/ansible/ansible-pull-cmd-line.sh
+    dialog --keep-window --begin 2 20  --infobox "[+] Command line stored in /var/lib/ansible/ansible-pull-cmd-line.sh\n\n$ANSIBLE_BIN -C $BRANCH -d $ANSIBLECUBE_PATH -i hosts -U $GIT_REPO_URL main.yml --extra-vars \"$MANAGMENT $NAME $TIMEZONE $HOST_NAME $CONFIGURE $WIFIPWD $GIT_BRANCH\" $TAGS" 8 150 \
        --and-widget  --begin 11 20 --title "[+] Log in /var/log/ansible-pull.log" --tailbox    /var/log/ansible-pull.log  35 150
     
     clear

--- a/group_vars/all
+++ b/group_vars/all
@@ -18,6 +18,7 @@ kiwix_version: "0.9"
 mongodb_version: "2.4.10"
 own_config_file: False
 ideascube_upgrade_frozen: False
+git_branch: oneUpdateFile
 
 #Apps path
 mook_path: /home/{{ username }}

--- a/roles/network-manager/templates/nm-dispatcher.j2
+++ b/roles/network-manager/templates/nm-dispatcher.j2
@@ -10,7 +10,7 @@ if [[ "$IF" == eth* || "$IF" == "wlan1" ]] && [ -z "$PROC"  ]
 then
     case "$STATUS" in
         up)
-			/usr/local/bin/ansible-pull {% if ansible_default_ipv4.gateway != bsf_gateway %}-o{% endif %} -s 120 -C oneUpdateFile -d /var/lib/ansible/local -i hosts -U https://github.com/ideascube/ansiblecube.git main.yml --tags "update" >> /var/log/ansible-pull.log 2>&1
+			/usr/local/bin/ansible-pull {% if ansible_default_ipv4.gateway != bsf_gateway %}-o{% endif %} -s 120 -C {{ git_branch }} -d /var/lib/ansible/local -i hosts -U https://github.com/ideascube/ansiblecube.git main.yml --tags "update" >> /var/log/ansible-pull.log 2>&1
         ;;
         *)
             exit 0;


### PR DESCRIPTION
The branch name is not only set for ansible-pull but also for
/etc/NetworkManager/dispatcher.d/ansiblePullUpdate.

This way if the device has to reboot the branch called will be the one
given to buildMyCube.sh and not the default one