### PR TITLE
Enable uwsgi cache

### DIFF
--- a/roles/ideascube/files/uwsgi-cache.ini
+++ b/roles/ideascube/files/uwsgi-cache.ini
@@ -1,0 +1,19 @@
+# create a cache with 100 items (default size per-item is 64k)
+cache2 = name=ideascube,items=100
+
+# Goto cacheme if the user is not logged in as admin otherwise continue
+route-if = empty:${cookie[sessionid]} goto:cacheme
+route-run = continue:
+
+# Cache home, blog and mediacenter
+route-label = cacheme
+route = ^/[a-z]{2}/$ cache:key=${REQUEST_URI},name=ideascube
+route = ^/[a-z]{2}/$ cachestore:key=${REQUEST_URI},name=ideascube,expires=60
+route = ^/[a-z]{2}/blog/$ cache:key=${REQUEST_URI},name=ideascube
+route = ^/[a-z]{2}/blog/$ cachestore:key=${REQUEST_URI},name=ideascube,expires=60
+route-uri = ^/[a-z]{2}/mediacenter/\?source=(.*)$ cache:key=${REQUEST_URI},name=ideascube
+route-uri = ^/[a-z]{2}/mediacenter/\?source=(.*)$ cachestore:key=${REQUEST_URI},name=ideascube,expires=60
+route-uri = ^/[a-z]{2}/mediacenter/\?page=\d$ cache:key=${REQUEST_URI},name=ideascube
+route-uri = ^/[a-z]{2}/mediacenter/\?page=\d$ cachestore:key=${REQUEST_URI},name=ideascube,expires=60
+route-uri = ^/[a-z]{2}/mediacenter/$ cache:key=${REQUEST_URI},name=ideascube
+route-uri = ^/[a-z]{2}/mediacenter/$ cachestore:key=${REQUEST_URI},name=ideascube,expires=60

--- a/roles/ideascube/files/uwsgi-cache.ini
+++ b/roles/ideascube/files/uwsgi-cache.ini
@@ -8,12 +8,12 @@ route-run = continue:
 # Cache home, blog and mediacenter
 route-label = cacheme
 route = ^/[a-z]{2}/$ cache:key=${REQUEST_URI},name=ideascube
-route = ^/[a-z]{2}/$ cachestore:key=${REQUEST_URI},name=ideascube,expires=60
+route = ^/[a-z]{2}/$ cachestore:key=${REQUEST_URI},name=ideascube,expires=300
 route = ^/[a-z]{2}/blog/$ cache:key=${REQUEST_URI},name=ideascube
-route = ^/[a-z]{2}/blog/$ cachestore:key=${REQUEST_URI},name=ideascube,expires=60
+route = ^/[a-z]{2}/blog/$ cachestore:key=${REQUEST_URI},name=ideascube,expires=300
 route-uri = ^/[a-z]{2}/mediacenter/\?source=(.*)$ cache:key=${REQUEST_URI},name=ideascube
-route-uri = ^/[a-z]{2}/mediacenter/\?source=(.*)$ cachestore:key=${REQUEST_URI},name=ideascube,expires=60
+route-uri = ^/[a-z]{2}/mediacenter/\?source=(.*)$ cachestore:key=${REQUEST_URI},name=ideascube,expires=300
 route-uri = ^/[a-z]{2}/mediacenter/\?page=\d$ cache:key=${REQUEST_URI},name=ideascube
-route-uri = ^/[a-z]{2}/mediacenter/\?page=\d$ cachestore:key=${REQUEST_URI},name=ideascube,expires=60
+route-uri = ^/[a-z]{2}/mediacenter/\?page=\d$ cachestore:key=${REQUEST_URI},name=ideascube,expires=300
 route-uri = ^/[a-z]{2}/mediacenter/$ cache:key=${REQUEST_URI},name=ideascube
-route-uri = ^/[a-z]{2}/mediacenter/$ cachestore:key=${REQUEST_URI},name=ideascube,expires=60
+route-uri = ^/[a-z]{2}/mediacenter/$ cachestore:key=${REQUEST_URI},name=ideascube,expires=300

--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -94,6 +94,20 @@
   file: path=/etc/apt/apt.conf.d/9999IDEASCUBEISABADBADBOY state=absent
   tags: ['master', 'custom', 'update']
 
+- name: Add router_cache to plugin uwsgi list
+  lineinfile: dest=/etc/uwsgi/apps-enabled/ideascube.ini
+              regexp='plugins'
+              line='plugins         = python3,router_cache'
+              state=present
+  tags:
+    - update
+
+- name: Create and set up a cache for uwsgi
+  blockinfile: block="{{ lookup('file', 'uwsgi-cache.ini') }}" dest="/etc/uwsgi/apps-enabled/ideascube.ini"
+  notify: restart uwsgi
+  tags:
+    - update
+
 - name: Enable cards on homepage for ideascube upgrading from < 0.13.0
   become: yes
   become_user: ideascube


### PR DESCRIPTION
We cache home, blog and mediacenter. Cache is flushed every 5min.
Gain is about 8x faster on the KoomBook.
If the user is logged in as administrator the cache is disable.