### PR TITLE
Do not run the Ideascube migrations

### DIFF
--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -42,12 +42,6 @@
   when: (ansible_architecture == "armhf" or ansible_architecture == "armv7l")
     and (sda1.stat.isblk| default (omit)) == True
 
-- name: Run migration for ideascube
-  become: yes
-  become_user: ideascube
-  shell: ideascube migrate --database=default && ideascube migrate --database=transient
-  tags: ['master', 'custom']
-
 - block:
   - name: Backup data before upgrading
     shell: cp /var/ideascube/main/default.sqlite /var/ideascube/main/default.sqlite-{{ ideascube_installed }}-{{ ansible_date_time["date"] }}-{{ ansible_date_time["time"] }}


### PR DESCRIPTION
They are run automatically when starting the application, so this is not
needed.

And in fact, it was potentially harmful because if the application is
running while Ansible tries to run the migrations, then 2 processes
would try accessing the database at the same time, which is not possible
with SQLite.

This was added by commit 5306305:

    commit 5306305914d63916fe530bda63f1f5fb30ba3eb9
    Author: fheslouin <florian.heslouin@bibliosansfrontieres.org>
    Date:   Thu Jun 1 15:13:09 2017 +0200

        Run migration for ideascube

        New ideascube version (0.28.x) needs us to run migration manually

This was probably a misunderstanding, because Ideascube > 0.28.x does
not need this.

And in fact, Ideascube never needed Ansible to run the migrations:
before 0.28 it was done in post-install of the Debian package, starting
with 0.28 it is done at application startup.

On the same day, commit 8a558ed removed the migration runs from
ansiblecube, probably because Florian and I had cleared the
misunderstanding.

Unfortunately, commit 5306305 had added this twice, but commit 8a558ed
removed only one of the two instances.

This commit now removes the leftover instance.