### PR TITLE
fix conditional when no sda1

### DIFF
--- a/roles/system/tasks/raspberry.yml
+++ b/roles/system/tasks/raspberry.yml
@@ -1,11 +1,11 @@
 ---
 - name: Ensure the HDD mountpoint exists
   file: path=/media/hdd state=directory mode=0755
-  when: sda1.stat.isblk == True 
+  when: sda1.stat.isblk | default(omit) == True
   tags: ['custom','update']
 
 - name: Mount /dev/sda1
   mount: name=/media/hdd/ src=/dev/sda1 fstype=ext4 state=mounted opts=noatime,nofail
-  when: sda1.stat.isblk == True
+  when: sda1.stat.isblk | default(omit) == True
   tags:
     - custom


### PR DESCRIPTION
if there is no sda 1 then it fails with
```
TASK [Ensure the HDD mountpoint exists] ****************************************
fatal: [localhost]: FAILED! => {
"failed": true, 
"msg": "The conditional check 'sda1.stat.isblk == True' failed. The error was: error while evaluating conditional (sda1.stat.isblk == True): 'dict object' has no attribute 'isblk'\n\nThe error appears to have been in '/home/pi/playbook.yml': line 8, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Ensure the HDD mountpoint exists\n      ^ here\n"
}
```
