### PR TITLE
Display ideascube catalog install stdout.

### DIFF
--- a/roles/package_management/tasks/main.yml
+++ b/roles/package_management/tasks/main.yml
@@ -17,4 +17,10 @@
     {% else %}echo '[+] nothing to do'{% endif %}"
   with_items: '{{ ansible_local.device_list[generic_project_name].package_management | default(omit) }}'
   when: ansible_local.device_list[generic_project_name].package_management is defined
+  register: ideascube_catalog_cmd
+  tags: ['custom','update','package_management']
+
+- name: Print out what really happened
+  debug: msg={{ ideascube_catalog_cmd.stdout }}
+  when: ideascube_catalog_cmd.stdout is defined
   tags: ['custom','update','package_management']

--- a/roles/package_management/tasks/main.yml
+++ b/roles/package_management/tasks/main.yml
@@ -20,7 +20,9 @@
   register: ideascube_catalog_cmd
   tags: ['custom','update','package_management']
 
-- name: Print out what really happened
-  debug: msg={{ ideascube_catalog_cmd.stdout }}
-  when: ideascube_catalog_cmd.stdout is defined
+- set_fact:
+    pkg_list: "{{ ideascube_catalog_cmd.results | map(attribute='stdout') | list }}"
   tags: ['custom','update','package_management']
+
+- debug: var=pkg_list
+   tags: ['custom','update','package_management']

--- a/roles/package_management/tasks/main.yml
+++ b/roles/package_management/tasks/main.yml
@@ -25,4 +25,4 @@
   tags: ['custom','update','package_management']
 
 - debug: var=pkg_list
-   tags: ['custom','update','package_management']
+  tags: ['custom','update','package_management']


### PR DESCRIPTION
Ideascube catalog install will always have an exit code of 0, as soon as at least one package installs correctly. Therefor, as ansible is not displaying enough information about package installation, we may miss some of them.