### PR TITLE
Add the idcstats script to the logs/ role.

### DIFF
--- a/roles/logs/files/idcstats.sh
+++ b/roles/logs/files/idcstats.sh
@@ -36,10 +36,16 @@ sqcount() {
 
 users=$(  sqcount ideascube_user )
 staff=$(  squery "select count(*) from ideascube_user where is_staff = 1" )
+
 medias=$( sqcount mediacenter_document )
 tags=$(   sqcount taggit_tag )
+
 books=$(  sqcount library_book )
-blog=$(   sqcount blog_content )
+
+blogposts=$(     sqcount blog_content )
+blogdrafts=$(    squery "select count(*) from blog_content where status = 1" )
+blogpublished=$( squery "select count(*) from blog_content where status = 2" )
+blogdeleted=$(   squery "select count(*) from blog_content where status = 3" )
 
 # send this to syslog - no need of a separated file, use grep/awk/whatever
-logger --tag idcstats "$users users, $staff staffs, $medias medias, $tags tags, $blog blogposts, $books books"
+logger --tag idcstats "$users users, $staff staffs, $medias medias, $tags tags, $blogposts blogposts, $blogdrafts blogdrafts, $blogpublished blogpublished, $blogdeleted blogdeleted, $books books"

--- a/roles/logs/files/idcstats.sh
+++ b/roles/logs/files/idcstats.sh
@@ -35,11 +35,11 @@ sqcount() {
 #
 
 users=$(  sqcount ideascube_user )
+staff=$(  squery "select count(*) from ideascube_user where is_staff = 1" )
 medias=$( sqcount mediacenter_document )
 tags=$(   sqcount taggit_tag )
 books=$(  sqcount library_book )
 blog=$(   sqcount blog_content )
 
 # send this to syslog - no need of a separated file, use grep/awk/whatever
-logger --tag idcstats "$users users, $medias medias, $tags tags, $blog blogposts, $books books"
-
+logger --tag idcstats "$users users, $staff staffs, $medias medias, $tags tags, $blog blogposts, $books books"

--- a/roles/logs/files/idcstats.sh
+++ b/roles/logs/files/idcstats.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# idcstats -- quick'n'dirty stats from ideascube
+# Don't edit this script localy, it will be overwritten by ansiblecube anyway.
+
+
+#
+# conf / vars
+#
+
+DB=/var/ideascube/main/default.sqlite
+
+
+
+#
+# functions
+#
+
+# squery -- queries the sqlite database
+#   Usage: squery $query
+squery() {
+    sqlite3 $DB "$@"
+}
+
+# sqcount -- counts entries from a table
+#   Usage: sqcount $table
+sqcount() {
+    squery "select count(*) from $1"
+}
+
+
+
+#
+# main
+#
+
+users=$(  sqcount ideascube_user )
+medias=$( sqcount mediacenter_document )
+tags=$(   sqcount taggit_tag )
+books=$(  sqcount library_book )
+blog=$(   sqcount blog_content )
+
+# send this to syslog - no need of a separated file, use grep/awk/whatever
+logger --tag idcstats "$users users, $medias medias, $tags tags, $blog blogposts, $books books"
+

--- a/roles/logs/tasks/main.yml
+++ b/roles/logs/tasks/main.yml
@@ -34,5 +34,16 @@
 - name: fix rights on ansible-pull.log
   file: path=/var/log/ansible-pull.log mode=0644 group=adm
 
+- name: copy idcstats script
+  copy: src=idcstats.sh dest=/usr/local/bin/idcstats.sh mode=755
+
+- name: Add a cron entry to run the idcstats script
+  cron:
+    name: "Run idcstats"
+    hour: "*/6"
+    job: "/usr/local/bin/idcstats.sh"
+    state: present
+  tags: ['custom', 'update']
+
 - name: Say Hi on the logs
   shell: wget http://report.bsf-intranet.org/device={{ansible_hostname}}/ansiblepull=IamOnOldMasterBranch

--- a/roles/logs/tasks/main.yml
+++ b/roles/logs/tasks/main.yml
@@ -43,7 +43,6 @@
     hour: "*/6"
     job: "/usr/local/bin/idcstats.sh"
     state: present
-  tags: ['custom', 'update']
 
 - name: Say Hi on the logs
   shell: wget http://report.bsf-intranet.org/device={{ansible_hostname}}/ansiblepull=IamOnOldMasterBranch


### PR DESCRIPTION
This script sends some basic stats from ideascube to syslog, 4 times a day.
The output is quite easy to parse using awk for example. The syslog
facility is used so we don't need to take care of a new file.

This is a loose cherry-pick from the oneUpdateFile branch.
0e305442201cc8621d89a515ced67fdb686a41ab