### PR TITLE
Remove device tree management for new image

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -140,8 +140,9 @@
     - custom
 
 - include: lime2.yml
-  when: fex_file.stat.exists is defined and fex_file.stat.exists 
-    or dtb_file.stat.exists is defined and dtb_file.stat.exists
+  when: (fex_file.stat.exists is defined and fex_file.stat.exists 
+    or dtb_file.stat.exists is defined and dtb_file.stat.exists)
+    and ansible_kernel | version_compare('4.11', '<')
 
 - name: List services to restart (1/2)
   shell: checkrestart | grep ^service | awk '{print $2}'

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -142,7 +142,7 @@
 - include: lime2.yml
   when: (fex_file.stat.exists is defined and fex_file.stat.exists 
     or dtb_file.stat.exists is defined and dtb_file.stat.exists)
-    and ansible_kernel | version_compare('4.11', '<')
+    and ansible_kernel | version_compare('4.11.0', '<')
 
 - name: List services to restart (1/2)
   shell: checkrestart | grep ^service | awk '{print $2}'


### PR DESCRIPTION
With our new master image for KoomBook, device tree customization and
u-boot tweak are done directly during image build. There is no need to
apply those tasks if kernel is above 4.11.0