### PR TITLE
Disabling faulty include.

### DIFF
--- a/roles/kiwix/tasks/kiwix.yml
+++ b/roles/kiwix/tasks/kiwix.yml
@@ -97,22 +97,22 @@
   notify: restart kiwix
   tags: ['master','update']
 
-- name: check for wikipedia rc.d files
-  shell: ls /etc/rc5.d/S*wikipedia ; echo
-  register: file_exist
-  tags:
-    - update
-
-- name: parse rc.d files check output
-  stat: path={{file_exist.stdout}}
-  register: st
-  tags:
-    - update
-
-- include: dust-removal.yml
-  when: st.stat.exists == True
-  tags:
-    - update
+#- name: check for wikipedia rc.d files
+#  shell: ls /etc/rc5.d/S*wikipedia ; echo
+#  register: file_exist
+#  tags:
+#    - update
+#
+#- name: parse rc.d files check output
+#  stat: path={{file_exist.stdout}}
+#  register: st
+#  tags:
+#    - update
+#
+#- include: dust-removal.yml
+#  when: st.stat.exists == True
+#  tags:
+#    - update
 
 # - name: Checkout installed.yml file size 
 #   stat: path=/var/ideascube/main/catalog/installed.yml


### PR DESCRIPTION
Including dust-removal.yml which has a task calling for a fake catalog kiwix.yml, but located on a remote server. The file is gone, no backup, we just don't know what was its purpose. Waiting for @fheslouin to give us a hint. In the meantime, just don't do dust-removal and let the thing dirty a bit longer.