### PR TITLE
locally resolve servers own hostname

### DIFF
--- a/roles/system/templates/hosts.j2
+++ b/roles/system/templates/hosts.j2
@@ -1,4 +1,4 @@
-127.0.0.1   localhost {{ ansible_local.installed_software.management.hostname }} kiwix.{{ ansible_local.installed_software.management.hostname }} khanacademy.{{ ansible_local.installed_software.management.hostname }} sites.{{ ansible_local.installed_software.management.hostname }} kolibri.{{ ansible_local.installed_software.management.hostname }} mail.{{ ansible_local.installed_software.management.hostname }}
+127.0.0.1   localhost {{ ansible_local.installed_software.management.hostname }} kiwix.{{ ansible_local.installed_software.management.hostname }} khanacademy.{{ ansible_local.installed_software.management.hostname }} sites.{{ ansible_local.installed_software.management.hostname }} kolibri.{{ ansible_local.installed_software.management.hostname }} mail.{{ ansible_local.installed_software.management.hostname }} {{ ansible_hostname }}
 fe00::0     ip6-localnet
 ff00::0     ip6-mcastprefix
 ff02::1     ip6-allnodes


### PR DESCRIPTION
    Adding a way to locally resolve hostname.
    Funny fact is we didn't make sure that a koombook could resolve its own hostname. Our office setup always included a DNS server fed by DHCP.
    Not being able to resolve its own hostname is a nogo for sudo for example, captive portal is entirely relying on sudo...
