### PR TITLE
Telegraf implementation for resource usage graph.

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -66,6 +66,10 @@
       when: ansible_local.installed_software.management.managed_by_bsf|bool == True
       tags: ['master','update']
 
+    - role: telegraf
+      when: ansible_local.installed_software.management.managed_by_bsf|bool == True
+      tags: ['master','update']
+
     - role: samba
       when: ansible_local.device_list[generic_project_name].samba is defined
         and ansible_local.device_list[generic_project_name].samba|bool == True

--- a/main.yml
+++ b/main.yml
@@ -64,7 +64,7 @@
 
     - role: telegraf
       when: ansible_local.installed_software.management.managed_by_bsf|bool == True
-      tags: ['master','update']
+      tags: ['custom','update']
 
     - role: samba
       when: ansible_local.device_list[generic_project_name].samba is defined

--- a/main.yml
+++ b/main.yml
@@ -62,6 +62,10 @@
       when: ansible_local.installed_software.management.managed_by_bsf|bool == True
       tags: ['master','update']
 
+    - role: telegraf
+      when: ansible_local.installed_software.management.managed_by_bsf|bool == True
+      tags: ['master','update']
+
     - role: samba
       when: ansible_local.device_list[generic_project_name].samba is defined
         and ansible_local.device_list[generic_project_name].samba|bool == True

--- a/roles/logs/tasks/main.yml
+++ b/roles/logs/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: Create BSF log directory
   file:
     path: "{{ bsf_log_folder }}"
+    owner: "{{ username }}"
+    group: adm
+    mode: 0775
     state: directory
 
 - name: Configure logrotate to handle our custom logs.

--- a/roles/set_custom_fact/files/device_list.fact
+++ b/roles/set_custom_fact/files/device_list.fact
@@ -3303,9 +3303,7 @@
       "syncthing_master_id_device": ""
     },
     "modoboa": {
-        "activated": "True",
-        "mx_domain": "mail.ideas-box.cc",
-        "tinc_relay_mail_server": "192.168.10.254"
+        "activated": "False"
     },
     "vpn": {
         "name": "email",

--- a/roles/telegraf/files/nginx-vhost
+++ b/roles/telegraf/files/nginx-vhost
@@ -1,6 +1,6 @@
 server {
   listen 127.0.0.1:1081;
-  server_name_;
+  server_name _;
   location /server_status {
     stub_status on;
     access_log  off;

--- a/roles/telegraf/files/nginx-vhost
+++ b/roles/telegraf/files/nginx-vhost
@@ -1,0 +1,8 @@
+server {
+  listen 127.0.0.1:1081;
+  server_name_;
+  location /server_status {
+    stub_status on;
+    access_log  off;
+  }
+}

--- a/roles/telegraf/handlers/main.yml
+++ b/roles/telegraf/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: restart nginx
+  service: name=nginx state=restarted
+  tags: ['custom', 'update']
+  
+- name: restart telegraf
+  service: name=telegraf state=restarted
+  tags: ['custom', 'update']

--- a/roles/telegraf/tasks/main.yml
+++ b/roles/telegraf/tasks/main.yml
@@ -39,8 +39,17 @@
 
 - name: Enable nginx vhost for server-status
   file:
-   src: /etc/nginx/sites-available/server_status
-   dest: /etc/nginx/sites-enabled/server_status
-   state: link
+    src: /etc/nginx/sites-available/server_status
+    dest: /etc/nginx/sites-enabled/server_status
+    state: link
   notify: restart nginx
+  tags: ['custom','update']
+
+- name: Make sure logs are rotated
+  template:
+    src: telegraf-logrotate.j2
+    dest: /etc/logrotate.d/telegraf-metrics
+    owner: root
+    group: root
+    mode: 0644
   tags: ['custom','update']

--- a/roles/telegraf/tasks/main.yml
+++ b/roles/telegraf/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Check if telegraf is installed
+  command: dpkg-query -W telegraf
+  register: is_installed
+  failed_when: False
+  changed_when: is_installed.rc == 1 
+  tags: ['custom','update']
+
+- name: Download and install telegraf if needed for AMD64 platform
+  apt:
+    deb: "{{ filer_bsf }}/telegraf_1.4.4-1_amd64.deb"
+  when: ansible_architecture == 'amd64'
+    and is_installed.rc == 1
+  tags: ['custom','update']
+
+- name: Download and install telegraf if needed for ARM platform
+  apt:
+    deb: "{{ filer_bsf }}/telegraf_1.4.4-1_armhf.deb"
+  when: ansible_architecture == 'armv7l'
+    and is_installed.rc == 1
+  tags: ['custom','update']
+
+- name: Set telegraf conf file.
+  template: 
+    src: telegraf.j2
+    dest: /etc/telegraf/telegraf.conf 
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart telegraf
+  tags: ['custom','update']
+
+- name: Enabling a special vhost allowing to get server status informations
+  copy:
+    src: nginx-vhost
+    dest: /etc/nginx/sites-available/server_status
+  notify: restart nginx
+  tags: ['custom','update']
+
+- name: Enable nginx vhost for server-status
+  file:
+   src: /etc/nginx/sites-available/server_status
+   dest: /etc/nginx/sites-enabled/server_status state=link
+  notify: restart nginx
+  tags: ['custom','update']

--- a/roles/telegraf/tasks/main.yml
+++ b/roles/telegraf/tasks/main.yml
@@ -40,6 +40,7 @@
 - name: Enable nginx vhost for server-status
   file:
    src: /etc/nginx/sites-available/server_status
-   dest: /etc/nginx/sites-enabled/server_status state=link
+   dest: /etc/nginx/sites-enabled/server_status
+   state: link
   notify: restart nginx
   tags: ['custom','update']

--- a/roles/telegraf/tasks/main.yml
+++ b/roles/telegraf/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and install telegraf if needed for AMD64 platform
   apt:
     deb: "{{ filer_bsf }}/telegraf_1.4.4-1_amd64.deb"
-  when: ansible_architecture == 'amd64'
+  when: ansible_architecture == 'x86_64'
     and is_installed.rc == 1
   tags: ['custom','update']
 

--- a/roles/telegraf/tasks/main.yml
+++ b/roles/telegraf/tasks/main.yml
@@ -20,6 +20,13 @@
     and is_installed.rc == 1
   tags: ['custom','update']
 
+- name: Adds telegraf user to adm group for log writing purpose
+  user:
+    name: telegraf
+    groups: adm
+    append: yes
+  tags: ['custom','update']
+
 - name: Set telegraf conf file.
   template: 
     src: telegraf.j2

--- a/roles/telegraf/templates/telegraf-logrotate.j2
+++ b/roles/telegraf/templates/telegraf-logrotate.j2
@@ -1,0 +1,16 @@
+#
+# {{ ansible_managed }}
+#
+
+{{ bsf_log_folder }}/{{ ansible_hostname }}_telegraf-metrics.log {
+    weekly
+    rotate 52
+    compress
+    delaycompress
+    missingok
+    notifempty
+   # create 640 root adm
+    postrotate
+       /bin/systemctl reload telegraf > /dev/null
+    endscript
+}

--- a/roles/telegraf/templates/telegraf.j2
+++ b/roles/telegraf/templates/telegraf.j2
@@ -28,7 +28,6 @@
 [[inputs.filestat]]
   files = ["/var/log/**.log","{{ bsf_log_folder }}/{{ ansible_hostname }}_telegraf-metrics.log**"]
   md5 = false
-[[inputs.kernel]]
 [[inputs.mem]]
 [[inputs.nginx]]
   urls = ["http://localhost:1081/server_status"]

--- a/roles/telegraf/templates/telegraf.j2
+++ b/roles/telegraf/templates/telegraf.j2
@@ -1,0 +1,38 @@
+[global_tags]
+[agent]
+  interval = "60s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "10s"
+  flush_jitter = "0s"
+  precision = ""
+  debug = false
+  quiet = false
+  logfile = ""
+  hostname = ""
+  omit_hostname = false
+[[outputs.file]]
+  files = ["{{ bsf_log_folder }}/{{ ansible_hostname }}_telegraf-metrics.log"]
+  data_format = "graphite"
+  prefix = "nodes.{{ hotspot_name }}"
+[[inputs.cpu]]
+  percpu = false
+  totalcpu = true
+  collect_cpu_time = false
+  report_active = false
+[[inputs.disk]]
+  ignore_fs = ["tmpfs", "devtmpfs", "devfs"]
+[[inputs.diskio]]
+[[inputs.filestat]]
+  files = ["/var/log/**.log","{{ bsf_log_folder }}/{{ ansible_hostname }}_telegraf-metrics.log**"]
+  md5 = false
+[[inputs.kernel]]
+[[inputs.mem]]
+[[inputs.nginx]]
+  urls = ["http://localhost:1081/server_status"]
+  response_timeout = "5s"
+[[inputs.processes]]
+[[inputs.swap]]
+[[inputs.system]]


### PR DESCRIPTION
The purpose is to be able to graph resource usage on on-field device.
* resources are polled every 60s to keep logs size low.
* log files are compressed/rotated and push to central server
* polling information are directly exported in Graphite format.
* appart from pure resource polling (such as CPU/RAM/Disk/FileSize/Swap), has been added some nginx usage stats (active connections/total number of connection/etc.) 