### PR TITLE
Logrotate tweaks

### DIFF
--- a/roles/logs/tasks/main.yml
+++ b/roles/logs/tasks/main.yml
@@ -48,7 +48,7 @@
 - name: Ensure Anacron will run on battery
   lineinfile: 
     dest: /etc/default/anacron
-    regexp: '^ANACRON_RUN_ON_BATTERY_POWER=no'
+    regexp: '^ANACRON_RUN_ON_BATTERY_POWER'
     line: 'ANACRON_RUN_ON_BATTERY_POWER=yes'
     state: present
 

--- a/roles/logs/tasks/main.yml
+++ b/roles/logs/tasks/main.yml
@@ -45,3 +45,10 @@
 - name: copy APT User-Agent configuration
   copy: src=apt-user-agent.conf dest=/etc/apt/apt.conf.d/99useragent mode=755
 
+- name: Ensure Anacron will run on battery
+  lineinfile: 
+    dest: /etc/default/anacron
+    regexp: '^ANACRON_RUN_ON_BATTERY_POWER=no'
+    line: 'ANACRON_RUN_ON_BATTERY_POWER=yes'
+    state: present
+

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -86,6 +86,7 @@
    - apt-transport-https
    - iotop
    - htop
+   - anacron
   tags: ['master','custom','update']
 
 - name: Install avahi packages

--- a/roles/telegraf/templates/telegraf-logrotate.j2
+++ b/roles/telegraf/templates/telegraf-logrotate.j2
@@ -3,8 +3,8 @@
 #
 
 {{ bsf_log_folder }}/{{ ansible_hostname }}_telegraf-metrics.log {
-    weekly
-    rotate 52
+    daily
+    rotate 180
     compress
     missingok
     notifempty

--- a/roles/telegraf/templates/telegraf-logrotate.j2
+++ b/roles/telegraf/templates/telegraf-logrotate.j2
@@ -3,6 +3,7 @@
 #
 
 {{ bsf_log_folder }}/{{ ansible_hostname }}_telegraf-metrics.log {
+    su root adm
     daily
     rotate 180
     compress

--- a/roles/telegraf/templates/telegraf.j2
+++ b/roles/telegraf/templates/telegraf.j2
@@ -32,6 +32,5 @@
 [[inputs.nginx]]
   urls = ["http://localhost:1081/server_status"]
   response_timeout = "5s"
-[[inputs.processes]]
 [[inputs.swap]]
 [[inputs.system]]


### PR DESCRIPTION
Make sure cron jobs will run. Even if down at 6am.
Therefore : 
- Installing Anacron
- Allowing anacron to run on battery.
- reducing log size for telegraf : rotating daily + 6 month retention.