### PR TITLE
Modifying servers IP for idbvpn. To something less common..

### DIFF
--- a/roles/tinc-static/files/hosts/buildbot
+++ b/roles/tinc-static/files/hosts/buildbot
@@ -1,5 +1,5 @@
 Address = buildbot.wan.bsf-intranet.org
-Subnet = 10.80.100.2/32
+Subnet = 10.80.100.251/32
 Port = 656
 
 -----BEGIN RSA PUBLIC KEY-----

--- a/roles/tinc-static/files/hosts/tincmaster
+++ b/roles/tinc-static/files/hosts/tincmaster
@@ -1,5 +1,5 @@
 Address = tincmaster.wan.bsf-intranet.org
-Subnet = 10.80.100.1/32
+Subnet = 10.80.100.250/32
 Port = 656
 
 -----BEGIN RSA PUBLIC KEY-----


### PR DESCRIPTION
Too many device are getting IPs 10.80.100.1/2.
Server have already changed address for the following ones.