### PR TITLE
Making sure rule match when source and destination are in same subnet.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,7 +1,9 @@
 ---
 #Network
 hotspot_ip: 192.168.2.1
+hotspot_source_range : 192.168.2.2-192.168.2.254
 external_hotspot_ip: 192.168.3.1
+external_hotspot_source_range: 192.168.3.2-192.168.3.254
 hotspot_interface: wlan0
 lan_interface: eth0
 client_interface: wlan1

--- a/roles/captive_portal/tasks/enabled.yml
+++ b/roles/captive_portal/tasks/enabled.yml
@@ -165,19 +165,19 @@
 - name: Send to CAPTIVE_HTTP if destination *:80/tcp
   command: /sbin/iptables -t nat -A PREROUTING -p tcp -m tcp ! -d "{{ item.dst }}" --dport 80 -m iprange --src-range {{ item.src }} -j CAPTIVE_HTTP
   with_items:
-    - src: "{{ hotspot_ip }}"
-      dst: "{{ hotspot_source_range }}"
-    - src: "{{ external_hotspot_ip }}"
-      dst: "{{ external_hotspot_source_range }}"
+    - dst: "{{ hotspot_ip }}"
+      src: "{{ hotspot_source_range }}"
+    - dst: "{{ external_hotspot_ip }}"
+      src: "{{ external_hotspot_source_range }}"
   tags: ['custom', 'update']
 
 - name: Send to CAPTIVE_HTTPS if destination *:443/tcp
   command: /sbin/iptables -t nat -A PREROUTING -p tcp -m tcp ! -d "{{ item.dst }}" --dport 443 -m iprange --src-range {{ item.src }} -j CAPTIVE_HTTPS
   with_items:
-    - src: "{{ hotspot_ip }}"
-      dst: "{{ hotspot_source_range }}"
-    - src: "{{ external_hotspot_ip }}"
-      dst: "{{ external_hotspot_source_range }}"
+    - dst: "{{ hotspot_ip }}"
+      src: "{{ hotspot_source_range }}"
+    - dst: "{{ external_hotspot_ip }}"
+      src: "{{ external_hotspot_source_range }}"
   tags: ['custom', 'update']
 
 

--- a/roles/captive_portal/tasks/enabled.yml
+++ b/roles/captive_portal/tasks/enabled.yml
@@ -163,18 +163,23 @@
   ignore_errors: yes
 
 - name: Send to CAPTIVE_HTTP if destination *:80/tcp
-  command: /sbin/iptables -t nat -A PREROUTING -p tcp -m tcp ! -s "{{ item }}" ! -d "{{ item }}" --dport 80 -j CAPTIVE_HTTP
+  command: /sbin/iptables -t nat -A PREROUTING -p tcp -m tcp ! -d "{{ item.dst }}" --dports 80 -m iprange --src-range {{ item.src }} -j CAPTIVE_HTTP
   with_items:
-    - "{{ hotspot_ip }}"
-    - "{{external_hotspot_ip}}"
+    - src: "{{ hotspot_ip }}"
+      dst: "{{ hotspot_source_range }}"
+    - src: "{{ external_hotspot_ip }}"
+      dst: "{{ external_hotspot_source_range }}"
   tags: ['custom', 'update']
 
 - name: Send to CAPTIVE_HTTPS if destination *:443/tcp
-  command: iptables -t nat -A PREROUTING -p tcp -m tcp ! -s "{{ item }}" ! -d "{{ item }}" --dport 443 -j CAPTIVE_HTTPS
+  command: /sbin/iptables -t nat -A PREROUTING -p tcp -m tcp ! -d "{{ item.dst }}" --dports 443 -m iprange --src-range {{ item.src }} -j CAPTIVE_HTTPS
   with_items:
-    - "{{ hotspot_ip }}"
-    - "{{external_hotspot_ip}}"
+    - src: "{{ hotspot_ip }}"
+      dst: "{{ hotspot_source_range }}"
+    - src: "{{ external_hotspot_ip }}"
+      dst: "{{ external_hotspot_source_range }}"
   tags: ['custom', 'update']
+
 
 - name: From CAPTIVE_HTTP, send to CAPTIVE_PASSLIST
   iptables:

--- a/roles/captive_portal/tasks/enabled.yml
+++ b/roles/captive_portal/tasks/enabled.yml
@@ -163,9 +163,7 @@
   ignore_errors: yes
 
 - name: Purge all chains
-  iptables:
-    table: nat
-    flush: "{{item}}"
+  command: /sbin/iptables -t nat -F "{{item}}"
   with_items:
     - PREROUTING
     - CAPTIVE_HTTPS

--- a/roles/captive_portal/tasks/enabled.yml
+++ b/roles/captive_portal/tasks/enabled.yml
@@ -162,6 +162,17 @@
   tags: ['custom', 'update']
   ignore_errors: yes
 
+- name: Purge all chains
+  iptables:
+    table: nat
+    flush: "{{item}}"
+  with_items:
+    - PREROUTING
+    - CAPTIVE_HTTPS
+    - CAPTIVE_HTTP
+    - CAPTIVE_PASSLIST
+  tags: ['custom', 'update']
+
 - name: Send to CAPTIVE_HTTP if destination *:80/tcp
   command: /sbin/iptables -t nat -A PREROUTING -p tcp -m tcp ! -d "{{ item.dst }}" --dport 80 -m iprange --src-range {{ item.src }} -j CAPTIVE_HTTP
   with_items:

--- a/roles/captive_portal/tasks/enabled.yml
+++ b/roles/captive_portal/tasks/enabled.yml
@@ -163,7 +163,7 @@
   ignore_errors: yes
 
 - name: Send to CAPTIVE_HTTP if destination *:80/tcp
-  command: /sbin/iptables -t nat -A PREROUTING -p tcp -m tcp ! -d "{{ item.dst }}" --dports 80 -m iprange --src-range {{ item.src }} -j CAPTIVE_HTTP
+  command: /sbin/iptables -t nat -A PREROUTING -p tcp -m tcp ! -d "{{ item.dst }}" --dport 80 -m iprange --src-range {{ item.src }} -j CAPTIVE_HTTP
   with_items:
     - src: "{{ hotspot_ip }}"
       dst: "{{ hotspot_source_range }}"
@@ -172,7 +172,7 @@
   tags: ['custom', 'update']
 
 - name: Send to CAPTIVE_HTTPS if destination *:443/tcp
-  command: /sbin/iptables -t nat -A PREROUTING -p tcp -m tcp ! -d "{{ item.dst }}" --dports 443 -m iprange --src-range {{ item.src }} -j CAPTIVE_HTTPS
+  command: /sbin/iptables -t nat -A PREROUTING -p tcp -m tcp ! -d "{{ item.dst }}" --dport 443 -m iprange --src-range {{ item.src }} -j CAPTIVE_HTTPS
   with_items:
     - src: "{{ hotspot_ip }}"
       dst: "{{ hotspot_source_range }}"


### PR DESCRIPTION
If I understood the problem correctly, rules are matching for user coming from wrong subnet in external_antenna scenario.
This should fix as we are linking source_range to hotspot_ip.
Warning, this has not been tested.