### PR TITLE
Add style.css to branding

### DIFF
--- a/roles/ideascube/tasks/branding.yml
+++ b/roles/ideascube/tasks/branding.yml
@@ -31,3 +31,13 @@
     force=yes
     timeout=30
   ignore_errors: yes
+
+- name: Install style.css branding resources
+  get_url: url={{ filer_bsf }}/branding/{{ ideascube_branding }}/style.css
+    dest=/usr/share/ideascube/static/branding/style.css
+    owner=ideascube
+    group=ideascube
+    mode=0644
+    force=yes
+    timeout=30
+  ignore_errors: yes


### PR DESCRIPTION
We can now download and use style.css as an override to main.css ideascube static file