### PR TITLE
Set ideascube domain name from env variable

### DIFF
--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -116,7 +116,7 @@
 - name: Add DOMAIN to set ideascube domain name
   lineinfile: dest=/etc/default/ideascube
               regexp='DOMAIN='
-              line='DOMAIN={{ ansible_hostname }}'
+              line='DOMAIN={{ hostname }}'
               state=present
   notify: restart uwsgi
   tags: ['custom','rename','update']

--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -113,6 +113,14 @@
   notify: restart uwsgi
   tags: ['custom','rename','update']
 
+- name: Add DOMAIN to set ideascube domain name
+  lineinfile: dest=/etc/default/ideascube
+              regexp='DOMAIN='
+              line='DOMAIN={{ ansible_hostname }}'
+              state=present
+  notify: restart uwsgi
+  tags: ['custom','rename','update']
+
 - name: Ensure that Ideascube folder belong the ideascube user
   command: chown -R {{ username }}:{{ username }} /var/ideascube/main/
   tags: 

--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -116,7 +116,7 @@
 - name: Add DOMAIN to set ideascube domain name
   lineinfile: dest=/etc/default/ideascube
               regexp='DOMAIN='
-              line='DOMAIN={{ hostname }}'
+              line='DOMAIN={{ ansible_local.installed_software.management.hostname }}'
               state=present
   notify: restart uwsgi
   tags: ['custom','rename','update']
@@ -134,7 +134,7 @@
 - name: Set Ideascube name
   become: yes
   become_user: ideascube
-  command: ideascube config set server site-name {{ hostname }}
+  command: ideascube config set server site-name {{ ansible_local.installed_software.management.hostname }}
   tags: ['master', 'custom']
 
 - name: Get ideascube version
@@ -175,7 +175,7 @@
     - update
 
 - name: Set hostname in nginx vhost
-  command: sed -i '/server_name/c\server_name {{ hostname }};' /etc/nginx/sites-available/ideascube
+  command: sed -i '/server_name/c\server_name {{ ansible_local.installed_software.management.hostname }};' /etc/nginx/sites-available/ideascube
   notify: restart uwsgi
   tags: ['custom','rename','update']
 

--- a/roles/ideascube/tasks/ideascube.yml
+++ b/roles/ideascube/tasks/ideascube.yml
@@ -174,6 +174,11 @@
   tags:
     - update
 
+- name: Set hostname in nginx vhost
+  command: sed -i '/server_name/c\server_name {{ hostname }};' /etc/nginx/sites-available/ideascube
+  notify: restart uwsgi
+  tags: ['custom','rename','update']
+
 - name: Create and set up a cache for uwsgi
   blockinfile: block="{{ lookup('file', 'uwsgi-cache.ini') }}" dest="/etc/uwsgi/apps-available/ideascube.ini"
   notify: restart uwsgi


### PR DESCRIPTION
We can now set `DOMAIN` in `/etc/default/ideascube`. This enable users to use other domain name than `koombook.lan` or `ideasbox.lan`