### PR TITLE
Ensure ideascube's user settings.

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -185,8 +185,7 @@
         ssh_key_file=.ssh/id_rsa
         password={{ password }}
         update_password={{ managed_by_bsf|bool | ternary('always', 'on_create') }}
-  tags:
-    - master
+  tags: ['master', 'update']
 
 - name: Set up authorized_keys for the ideascube user
   authorized_key: user={{username}} key="{{ item }}"


### PR DESCRIPTION
Applying this at the `upgrade` tags ensures existing devices will add
the `ideascube` user to the `adm` group.