### PR TITLE
Tm autodeploy

### DIFF
--- a/tools/koombook_zeroconf
+++ b/tools/koombook_zeroconf
@@ -53,7 +53,7 @@ if [[ -b /dev/sda && ! -b /dev/sda1 ]]; then
     apt-get -y install jq amqp-tools
 
     wget -O /tmp/get_amqp_output.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/get_amqp_output.sh
-    wget -O /tmp/read_from_amqp.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/read_from_amqp.sh
+    wget -O /tmp/read_from_amqp.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/read_from_amqp_koombook.sh
     chmod +x /tmp/get_amqp_output.sh
     chmod +x /tmp/read_from_amqp.sh
 

--- a/tools/koombook_zeroconf
+++ b/tools/koombook_zeroconf
@@ -51,6 +51,7 @@ if [[ -b /dev/sda && ! -b /dev/sda1 ]]; then
 
     # Get autodeploy script and run it.
     wget -q https://raw.githubusercontent.com/ideascube/ansiblecube/TM-autodeploy/tools/start_buildmycube.sh -O /tmp/start_buildmycube.sh
+    chmod +x /tmp/start_buildmycube.sh
     /tmp/start_buildmycube.sh koombook
 
     reboot

--- a/tools/koombook_zeroconf
+++ b/tools/koombook_zeroconf
@@ -54,8 +54,11 @@ if [[ -b /dev/sda && ! -b /dev/sda1 ]]; then
 
     wget -O /tmp/get_amqp_output.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/get_amqp_output.sh
     wget -O /tmp/read_from_amqp.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/read_from_amqp_koombook.sh
+    wget -O /tmp/send_to_log_queue.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/send_to_log_queue.sh
+
     chmod +x /tmp/get_amqp_output.sh
     chmod +x /tmp/read_from_amqp.sh
+    chmod +x /tmp/send_to_log_queue.sh
 
     output=$(/tmp/read_from_amqp.sh)
 
@@ -63,8 +66,16 @@ if [[ -b /dev/sda && ! -b /dev/sda1 ]]; then
     timeZone=$(echo output | jq '.timezone')
 
     # Start builMyCube
+    now=$(TZ="Europe/Paris" date +"%F %T,%3N")
+    inet_addr=$(ip a s eth0 | awk '/inet /  {print $2}')
+    macaddress=$( ip a s eth0 | awk ' /link\/ether/ { print $2 } ' )
+
+    /tmp/send_to_log_queue.sh "$now - INFO - Starting deployment of $deviceName on $inet_addr / $macaddress"
 
     /var/lib/ansible/local/buildMyCube.sh -n "$deviceName" -t "$timeZone"
+
+    now=$(TZ="Europe/Paris" date +"%F %T,%3N")
+    /tmp/send_to_log_queue.sh "$now - INFO - Finished deployment of $deviceName on $inet_addr / $macaddress"
 
     wget http://report.bsf-intranet.org/device=$device_hostname/KoomBookFirstInit=Success
 

--- a/tools/koombook_zeroconf
+++ b/tools/koombook_zeroconf
@@ -49,35 +49,9 @@ if [[ -b /dev/sda && ! -b /dev/sda1 ]]; then
     # Disable script
     chmod -x $0
 
-    # install dependencies
-    apt-get -y install jq amqp-tools
-
-    wget -O /tmp/get_amqp_output.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/get_amqp_output.sh
-    wget -O /tmp/read_from_amqp.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/read_from_amqp_koombook.sh
-    wget -O /tmp/send_to_log_queue.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/send_to_log_queue.sh
-
-    chmod +x /tmp/get_amqp_output.sh
-    chmod +x /tmp/read_from_amqp.sh
-    chmod +x /tmp/send_to_log_queue.sh
-
-    output=$(/tmp/read_from_amqp.sh)
-
-    deviceName=$(echo output | jq '.project_name')
-    timeZone=$(echo output | jq '.timezone')
-
-    # Start builMyCube
-    now=$(TZ="Europe/Paris" date +"%F %T,%3N")
-    inet_addr=$(ip a s eth0 | awk '/inet /  {print $2}')
-    macaddress=$( ip a s eth0 | awk ' /link\/ether/ { print $2 } ' )
-
-    /tmp/send_to_log_queue.sh "$now - INFO - Starting deployment of $deviceName on $inet_addr / $macaddress"
-
-    /var/lib/ansible/local/buildMyCube.sh -n "$deviceName" -t "$timeZone"
-
-    now=$(TZ="Europe/Paris" date +"%F %T,%3N")
-    /tmp/send_to_log_queue.sh "$now - INFO - Finished deployment of $deviceName on $inet_addr / $macaddress"
-
-    wget http://report.bsf-intranet.org/device=$device_hostname/KoomBookFirstInit=Success
+    # Get autodeploy script and run it.
+    wget -q https://raw.githubusercontent.com/ideascube/ansiblecube/TM-autodeploy/tools/start_buildmycube.sh -O /tmp/start_buildmycube.sh
+    /tmp/start_buildmycube.sh koombook
 
     reboot
 

--- a/tools/koombook_zeroconf
+++ b/tools/koombook_zeroconf
@@ -46,22 +46,24 @@ if [[ -b /dev/sda && ! -b /dev/sda1 ]]; then
     # Make sure udev rules are deleted for wifi usb dongle
     rm -f /etc/udev/rules.d/70-persistent-net.rules
 
-    macaddress=$( ip a s eth0 | awk ' /link\/ether/ { print $2 } ' )
-    wget http://preseed.cinema.montreuil.wan.bsf-intranet.org/getMyDeviceName?mac=${macaddress} -O /tmp/getMyDeviceName
-
-    deviceName=`cat /tmp/getMyDeviceName | cut -d ";" -f1`
-    timeZone=`cat /tmp/getMyDeviceName | cut -d ";" -f2`
-
-    if [ -z "$deviceName" ]
-    then
-        deviceName="koombook"
-        timeZone="Europe/Paris"
-    fi
-
-    # Disable script 
+    # Disable script
     chmod -x $0
 
+    # install dependencies
+    apt-get -y install jq amqp-tools
+
+    wget -O /tmp/get_amqp_output.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/get_amqp_output.sh
+    wget -O /tmp/read_from_amqp.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/read_from_amqp.sh
+    chmod +x /tmp/get_amqp_output.sh
+    chmod +x /tmp/read_from_amqp.sh
+
+    output=$(/tmp/read_from_amqp.sh)
+
+    deviceName=$(echo output | jq '.project_name')
+    timeZone=$(echo output | jq '.timezone')
+
     # Start builMyCube
+
     /var/lib/ansible/local/buildMyCube.sh -n "$deviceName" -t "$timeZone"
 
     wget http://report.bsf-intranet.org/device=$device_hostname/KoomBookFirstInit=Success

--- a/tools/start_buildmycube.sh
+++ b/tools/start_buildmycube.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+project_type="ideasbox"
+
+apt-get -y install jq amqp-tools
+
+wget -O /tmp/get_amqp_output.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/get_amqp_output.sh
+wget -O /tmp/read_from_amqp.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/read_from_amqp_$project_type.sh
+wget -O /tmp/send_to_log_queue.sh http://gogs/outils-interne/temps_modernes_v1/raw/master/send_to_log_queue.sh
+wget -O /tmp/buildMyCube.sh https://raw.githubusercontent.com/ideascube/ansiblecube/oneUpdateFile/buildMyCube.sh
+
+chmod +x /tmp/get_amqp_output.sh
+chmod +x /tmp/read_from_amqp.sh
+chmod +x /tmp/send_to_log_queue.sh
+chmod +x /tmp/buildMyCube.sh
+
+output=$(/tmp/read_from_amqp.sh)
+
+deviceName=$(echo $output | jq '.project_name')
+timeZone=$(echo $output | jq '.timezone')
+now=$(TZ="Europe/Paris" date +"%F %T,%3N")
+inet_addr=$(ip a s eth0 | awk '/inet /  {print $2}')
+macaddress=$( ip a s eth0 | awk ' /link\/ether/ { print $2 } ' )
+
+# Start builMyCube
+
+/tmp/send_to_log_queue.sh "$now - INFO - Starting deployment of $deviceName on $inet_addr / $macaddress"
+
+/tmp/buildMyCube.sh -n $deviceName -t "$timeZone" -q true -a master && \
+/tmp/buildMyCube.sh -n $deviceName -t "$timeZone" -q true -a custom
+
+now=$(TZ="Europe/Paris" date +"%F %T,%3N")
+/tmp/send_to_log_queue.sh "$now - INFO - Finished deployment of $deviceName on $inet_addr / $macaddress"
+
+wget http://report.bsf-intranet.org/device=$device_hostname/IdeasboxFirstInit=Success


### PR DESCRIPTION
Configuration is no longer read from preseed server, but from an AMQP message.
Basically `output=$(/tmp/read_from_amqp.sh)` will wait until a message appears in the "koombook" queue.
`buildmycube` will then be run with arguments provided in the message.
This is untested :|