### PR TITLE
hostapd: make the clients limit configurable.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -2,6 +2,7 @@
 #Network
 hotspot_ip: 192.168.2.1
 hotspot_source_range : 192.168.2.2-192.168.2.254
+hotspot_maxclients: 15
 external_hotspot_ip: 192.168.3.1
 external_hotspot_source_range: 192.168.3.2-192.168.3.254
 hotspot_interface: wlan0

--- a/group_vars/armhf.yml
+++ b/group_vars/armhf.yml
@@ -2,6 +2,7 @@
 #Network
 hostname: koombook.lan
 hotspot_name: koombook
+hotspot_maxclients: 15
 ideascube_project_name: koombook
 ideascube_branding: koombook
 old_kiwix_path: /media/hdd

--- a/group_vars/armv7l.yml
+++ b/group_vars/armv7l.yml
@@ -2,6 +2,7 @@
 #Network
 hostname: koombook.lan
 hotspot_name: koombook
+hotspot_maxclients: 15
 ideascube_project_name: koombook
 ideascube_branding: koombook
 managed_by_bsf: True

--- a/group_vars/x86_64.yml
+++ b/group_vars/x86_64.yml
@@ -2,6 +2,7 @@
 #Network
 hostname: ideasbox.lan
 hotspot_name: ideasbox
+hotspot_maxclients: 30
 ideascube_project_name: ideasbox
 ideascube_branding: ideasbox
 managed_by_bsf: True

--- a/roles/hostapd/templates/hostapd.conf.j2
+++ b/roles/hostapd/templates/hostapd.conf.j2
@@ -11,7 +11,7 @@ channel=1
 # MAC address access control (0 = accept by default)
 macaddr_acl=0
 # limit wifi conexion
-max_num_sta=15
+max_num_sta={{ hostapd_maxclients }}
 # dunno lol
 auth_algs=1
 # dont hide the SSID


### PR DESCRIPTION
We used to limit the amount of users able to connect to the hotspot.

A server and a KoomBook don't have the same antennas, same context.

This PR allows us to configure the limit. Defaults to 15 for all, then 15 for a KB and 30 for a server.