### PR TITLE
Fix/160 logrotate hwd info

### DIFF
--- a/roles/logs/tasks/main.yml
+++ b/roles/logs/tasks/main.yml
@@ -23,8 +23,12 @@
       dest: hwd-info
   tags: ['custom','update']
 
+- name: remove hdw info script from its previous location
+  file: path=/home/ideascube/hdw_info.sh state=absent
+  tags: ['update']
+
 - name: copy hdw info script
-  template: src=hdw_info.sh dest=/home/ideascube/hdw_info.sh mode=755
+  template: src=hdw_info.sh dest=/usr/local/bin/hdw_info.sh mode=755
   tags: ['custom','update']
 
 - name: Copy push_log.sh

--- a/roles/logs/tasks/main.yml
+++ b/roles/logs/tasks/main.yml
@@ -22,7 +22,7 @@
   tags: ['custom','update']
 
 - name: copy hdw info script
-  copy: src=hdw_info.sh dest=/home/ideascube/hdw_info.sh mode=755
+  template: src=hdw_info.sh dest=/home/ideascube/hdw_info.sh mode=755
   tags: ['custom','update']
 
 - name: Copy push_log.sh

--- a/roles/logs/tasks/main.yml
+++ b/roles/logs/tasks/main.yml
@@ -19,6 +19,8 @@
       dest: dpkg-list
     - src: pip-freeze.logrotate.j2
       dest: pip-freeze
+    - src: hwd-info.logrotate.j2
+      dest: hwd-info
   tags: ['custom','update']
 
 - name: copy hdw info script

--- a/roles/logs/templates/hdw_info.sh
+++ b/roles/logs/templates/hdw_info.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-FILE="/tmp/hdw_info.txt"
+FILE="{{ bsf_log_folder }}/hdw_info.txt"
 if [ -d /media/hdd/bsfcampus ] ; then
     echo "##################################" > $FILE
     echo "#          BSF Campus            #" >> $FILE

--- a/roles/logs/templates/hwd-info.logrotate.j2
+++ b/roles/logs/templates/hwd-info.logrotate.j2
@@ -1,0 +1,13 @@
+#
+# {{ ansible_managed }}
+#
+
+{{ bsf_log_folder }}/hwd_info.txt {
+    weekly
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 640 root adm
+}

--- a/roles/logs/templates/push_log.sh.j2
+++ b/roles/logs/templates/push_log.sh.j2
@@ -7,7 +7,7 @@ if [[ "$IF" == "eth0" || "$IF" == "wlan1" ]] && [ -z "$PROC"  ]
 then
     case "$STATUS" in
         up)
-            /home/ideascube/hdw_info.sh
+            usr/local/bin/hdw_info.sh
             dpkg -l > /var/log/apt/dpkg.list
             pip freeze > /var/log/pip.freeze
             iptables-save > /var/log/iptables.rules

--- a/roles/logs/templates/push_log.sh.j2
+++ b/roles/logs/templates/push_log.sh.j2
@@ -12,7 +12,7 @@ then
             pip freeze > /var/log/pip.freeze
             iptables-save > /var/log/iptables.rules
             sqlite3 /var/ideascube/main/default.sqlite "select id,title from mediacenter_document" | awk -F'|' '{print "\""$1"\": " $2}' > {{ bsf_log_folder }}/{{ ansible_hostname }}_ideascube_doc_mapping.yaml
-            rsync -azP /var/log/nginx/* /var/log/kern.log /var/log/messages /var/log/syslog* /var/log/ansible-pull.log /tmp/hdw_info.txt /var/log/ansible-pull.log* /var/log/apt/dpkg.list* /var/log/pip.freeze* /var/log/iptables.rules /var/log/uwsgi {{ bsf_log_folder }} {{ central_server }}:/ansible/logs/{{ ansible_hostname }}/
+            rsync -azP /var/log/nginx/* /var/log/kern.log /var/log/messages /var/log/syslog* /var/log/ansible-pull.log /var/log/ansible-pull.log* /var/log/apt/dpkg.list* /var/log/pip.freeze* /var/log/iptables.rules /var/log/uwsgi {{ bsf_log_folder }} {{ central_server }}:/ansible/logs/{{ ansible_hostname }}/
         ;;
         *)
         ;;


### PR DESCRIPTION
hdw_info.sh script is a template, so it can write the output to `{{ bsf_log_folder }}` ; it is logrotated, which fixes #160 ; while we're on it, place this script in `$PATH`.