### PR TITLE
Kolibri imports

### DIFF
--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+language:
+  fr: 878ec2e6f88c5c268b1be6f202833cd4
+  en: 1ceff53605e55bef987d88e0908658c5
+kolibri_bin: /home/ideascube/.kolibri/env/bin/python2 /home/ideascube/.kolibri/env/bin/kolibri

--- a/roles/kolibri/defaults/main.yml
+++ b/roles/kolibri/defaults/main.yml
@@ -2,4 +2,5 @@
 language:
   fr: 878ec2e6f88c5c268b1be6f202833cd4
   en: 1ceff53605e55bef987d88e0908658c5
+  sw: ec164fee25ee526296e68f7c10b1e169
 kolibri_bin: /home/ideascube/.kolibri/env/bin/python2 /home/ideascube/.kolibri/env/bin/kolibri

--- a/roles/kolibri/files/kolibri.service
+++ b/roles/kolibri/files/kolibri.service
@@ -4,14 +4,14 @@ Description=Kolibri server
 [Service]
 User=ideascube
 Group=ideascube
+WorkingDirectory=/home/ideascube
+RemainAfterExit=yes
+Type=oneshot
 ExecStart=/home/ideascube/.kolibri/env/bin/python2 /home/ideascube/.kolibri/env/bin/kolibri start
 ExecStop=/home/ideascube/.kolibri/env/bin/python2 /home/ideascube/.kolibri/env/bin/kolibri stop
-Restart=always
 TimeoutStopSec=60
 PIDFile=/var/run/kolibri.pid
 KillSignal=SIGINT
-Restart=on-failure
-RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/kolibri/handlers/main.yml
+++ b/roles/kolibri/handlers/main.yml
@@ -6,3 +6,7 @@
 - name: restart nginx
   service: name=nginx state=restarted
   tags: ['custom', 'update']
+
+- name: restart kolibri
+  service: name=kolibri state=restarted
+  tags: ['custom', 'update']

--- a/roles/kolibri/tasks/import_content.yml
+++ b/roles/kolibri/tasks/import_content.yml
@@ -21,3 +21,8 @@
     {{ kolibri_bin }} manage importchannel disk {{ language[item] }} /media/kolibri/khan/{{ item }}/
     && {{ kolibri_bin }} manage importcontent disk {{ language[item] }} /media/kolibri/khan/{{ item }}/
   with_items: "{{ ansible_local.device_list[generic_project_name].kolibri.language | default('fr')}}"
+
+- name: Unmounting share
+  mount:
+    name: /media/kolibri
+    state: absent

--- a/roles/kolibri/tasks/import_content.yml
+++ b/roles/kolibri/tasks/import_content.yml
@@ -14,7 +14,7 @@
     state: mounted
 
 - name: Import channels and content
-  become: yes²
+  become: yes
   become_user: "{{ username }}"
   notify: restart kolibri
   shell: >

--- a/roles/kolibri/tasks/import_content.yml
+++ b/roles/kolibri/tasks/import_content.yml
@@ -1,0 +1,23 @@
+---
+- name: Install cifs-utils
+  apt: name=cifs-utils state=present
+
+- name: Create a working dir for CIFS share
+  file: path=/media/koombookDoctor/ state=directory
+
+- name: Mount CIFS Share
+  mount:
+    name: /media/koombookDoctor
+    src: //{{koombookDoctor}}/kolibri
+    fstype: cifs
+    opts: guest
+    state: mounted
+
+- name: Import channels and content
+  become: yes
+  become_user: "{{ username }}"
+  notify: restart kolibri
+  shell: >
+    {{ kolibri_bin }} manage importchannel disk {{ language[item] }} /media/koombookDoctor/khan/{{ item }}/
+    && {{ kolibri_bin }} manage importcontent disk {{ language[item] }} /media/koombookDoctor/khan/{{ item }}/
+  with_items: "{{ ansible_local.device_list[generic_project_name].kolibri.language | default('fr')}}"

--- a/roles/kolibri/tasks/import_content.yml
+++ b/roles/kolibri/tasks/import_content.yml
@@ -3,21 +3,21 @@
   apt: name=cifs-utils state=present
 
 - name: Create a working dir for CIFS share
-  file: path=/media/koombookDoctor/ state=directory
+  file: path=/media/kolibri/ state=directory
 
 - name: Mount CIFS Share
   mount:
-    name: /media/koombookDoctor
+    name: /media/kolibri
     src: //{{koombookDoctor}}/kolibri
     fstype: cifs
     opts: guest
     state: mounted
 
 - name: Import channels and content
-  become: yes
+  become: yes²
   become_user: "{{ username }}"
   notify: restart kolibri
   shell: >
-    {{ kolibri_bin }} manage importchannel disk {{ language[item] }} /media/koombookDoctor/khan/{{ item }}/
-    && {{ kolibri_bin }} manage importcontent disk {{ language[item] }} /media/koombookDoctor/khan/{{ item }}/
+    {{ kolibri_bin }} manage importchannel disk {{ language[item] }} /media/kolibri/khan/{{ item }}/
+    && {{ kolibri_bin }} manage importcontent disk {{ language[item] }} /media/kolibri/khan/{{ item }}/
   with_items: "{{ ansible_local.device_list[generic_project_name].kolibri.language | default('fr')}}"

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -54,3 +54,8 @@
   tags:
     - custom
 
+- name: Import Kalite videos if we are at BSF
+  include: import_content.yml
+  when: cache_machine.state|default(omit) == "present"
+  tags: 
+    - custom

--- a/roles/kolibri/tasks/main.yml
+++ b/roles/kolibri/tasks/main.yml
@@ -54,7 +54,7 @@
   tags:
     - custom
 
-- name: Import Kalite videos if we are at BSF
+- name: Import Kolibri content if we are at BSF
   include: import_content.yml
   when: cache_machine.state|default(omit) == "present"
   tags: 


### PR DESCRIPTION
Now Kolibri can be installed and provisioned with KhanAcademy in french of english.

Device configuration is expected to have a block like : 
`    "kolibri": {
      "activated": "True",
      "version": "0.10.3",
      "language": [ "fr" ]
    },`.

_language_ is waiting for a list, available languages for now are "fr" and "en". Obviously _version_ is the only one tested for now, it may work with others, you try.
